### PR TITLE
Fixed 'int' object has no attribute 'isdigit' exception

### DIFF
--- a/src/mqtt.py
+++ b/src/mqtt.py
@@ -88,8 +88,8 @@ class Mqtt:
             if (model in self.event_based_sensors):
                 retain = False
             # fix for rgb format
-            if (key == "rgb" and value.isdigit()):
-                value = self._color_xiaomi_to_rgb(value)
+            if (key == "rgb" and str(value).isdigit()):
+                value = self._color_xiaomi_to_rgb(str(value))
             items[key] = value
 
         if self.json == True:


### PR DESCRIPTION
In case when gateway lighting was changed via Xiaomi app then an exception occurred:

```
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | --- Logging error ---
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | Traceback (most recent call last):
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/app/main.py", line 29, in process_gateway_messages
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     client.publish(model, sid, data_decoded)
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/app/mqtt.py", line 91, in publish
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     if (key == "rgb" and value.isdigit()):
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | AttributeError: 'int' object has no attribute 'isdigit'
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | During handling of the above exception, another exception occurred:
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | Traceback (most recent call last):
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/logging/__init__.py", line 992, in emit
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     msg = self.format(record)
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/logging/__init__.py", line 838, in format
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     return fmt.format(record)
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/logging/__init__.py", line 575, in format
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     record.message = record.getMessage()
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/logging/__init__.py", line 338, in getMessage
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     msg = msg % self.args
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | TypeError: not all arguments converted during string formatting
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | Call stack:
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/threading.py", line 884, in _bootstrap
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     self._bootstrap_inner()
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/threading.py", line 916, in _bootstrap_inner
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     self.run()
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/threading.py", line 864, in run
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     self._target(*self._args, **self._kwargs)
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/app/main.py", line 32, in process_gateway_messages
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     _LOGGER.error('Error while sending from gateway to mqtt: ', str(e))
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | Message: 'Error while sending from gateway to mqtt: '
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | Arguments: ("'int' object has no attribute 'isdigit'",)
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | --- Logging error ---
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | Traceback (most recent call last):
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/app/main.py", line 29, in process_gateway_messages
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     client.publish(model, sid, data_decoded)
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/app/mqtt.py", line 91, in publish
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     if (key == "rgb" and value.isdigit()):
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | AttributeError: 'int' object has no attribute 'isdigit'
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | During handling of the above exception, another exception occurred:
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | Traceback (most recent call last):
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/logging/__init__.py", line 992, in emit
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     msg = self.format(record)
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/logging/__init__.py", line 838, in format
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     return fmt.format(record)
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/logging/__init__.py", line 575, in format
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     record.message = record.getMessage()
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/logging/__init__.py", line 338, in getMessage
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     msg = msg % self.args
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | TypeError: not all arguments converted during string formatting
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | Call stack:
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/threading.py", line 884, in _bootstrap
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     self._bootstrap_inner()
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/threading.py", line 916, in _bootstrap_inner
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     self.run()
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/usr/local/lib/python3.6/threading.py", line 864, in run
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     self._target(*self._args, **self._kwargs)
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |   File "/app/main.py", line 32, in process_gateway_messages
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    |     _LOGGER.error('Error while sending from gateway to mqtt: ', str(e))
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | Message: 'Error while sending from gateway to mqtt: '
Feb 27 14:55:43 raspberrypi docker-compose[1896]: aqara    | Arguments: ("'int' object has no attribute 'isdigit'",)
```

This PR fixes it