### PR TITLE
Add support for environment variable to load the configuration 

### DIFF
--- a/src/yamlparser.py
+++ b/src/yamlparser.py
@@ -1,4 +1,5 @@
 import yaml
+from os import environ
 import logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -6,7 +7,10 @@ _LOGGER = logging.getLogger(__name__)
 
 def load_yaml(file):
     try:
-        stram = open(file, "r")
+        if environ.get("AQARA_MQTT_CONFIG") is not None:
+            stram = environ.get("AQARA_MQTT_CONFIG")
+        else:
+            stram = open(file, "r")
         yaml_data = yaml.load(stram)
         return yaml_data
     except Exception as e:


### PR DESCRIPTION
Hi,

A little something I'm using for some weeks with `docker-compose`. There's no more need to have a volume so it's easier to deploy. I'm using a `docker-compose.yml` like this one : 

```yml
version: '3'

services:
  aqara:
    image: monster1025/aqara-mqtt:1-armhf
    restart: always
    environment:
      AQARA_MQTT_CONFIG: |-
        mqtt:
          server: 127.0.0.1
          port: 1883
          username: username
          password: pwd
          prefix: home

        gateway:
          password: 12345667
          unwanted_data_fix: False
          polling_interval: 2
          polling_models:
            - motionx

        sids:
          # motion
          158d0001292a42:
            model: motion
            name: salon

          # buttons
          158d000129f700:
            model: switch
            name: kitchen

          # gateway
          f0b429cc25e8:
            model: gateway
            name: main

```